### PR TITLE
Enables configuring main window size

### DIFF
--- a/guikit/config.py
+++ b/guikit/config.py
@@ -2,7 +2,7 @@
 Settings for configuring the application general behavior, plugging collection and other
 aspects of the tool.
 """
-from typing import List
+from typing import List, Tuple
 
 from .plugins import collect_builtin_extensions
 
@@ -20,3 +20,6 @@ NOTEBOOK_LAYOUT: bool = True
 
 TAB_STYLE: str = "top"
 """Location of the tabs. Valid values are `top`, `bottom`, `left` and `right`."""
+
+SIZE_MAINWINDOW: Tuple[int, int] = (800, 600)
+"""Input for main window size."""

--- a/guikit/core.py
+++ b/guikit/core.py
@@ -10,7 +10,7 @@ instance can be access directly from the class anywhere else where you import th
 from __future__ import annotations
 
 import itertools
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import wx
 
@@ -71,10 +71,12 @@ class MainWindow(wx.Frame):
         self,
         parent,
         title: str,
+        size: Tuple[int, int],
         notebook_layout: bool = True,
         tab_style: int = wx.NB_TOP,
     ):
         super(MainWindow, self).__init__(parent, title=title)
+        self.size = size
         self.notebook_layout = notebook_layout
         self.tab_style = tab_style
         self.SetStatusBar(StatusBar(self))
@@ -87,7 +89,7 @@ class MainWindow(wx.Frame):
             self._make_central_widget()
         self._make_toolbar()
         self._make_menubar()
-        self.SetInitialSize(wx.Size(800, 600))
+        self.SetInitialSize(wx.Size(self.size))
 
     def _make_menubar(self) -> None:
         """Create the menu bar from the entries provided by the widgets."""
@@ -207,12 +209,14 @@ class MainApp(wx.App):
         self,
         *args,
         title: str,
+        size_mainwindow: Tuple[int, int],
         plugins_list: Optional[List[str]] = None,
         notebook_layout: bool = True,
         tab_style: str = "top",
         **kwargs,
     ):
         self.title = title
+        self.size_mainwindow = size_mainwindow
         self.plugins_list = plugins_list if plugins_list is not None else []
         self.notebook_layout = notebook_layout
         try:
@@ -228,7 +232,9 @@ class MainApp(wx.App):
 
     def OnInit(self) -> bool:
         self.SetAppName(self.title)
-        window = MainWindow(None, self.title, self.notebook_layout, self.tab_style)
+        window = MainWindow(
+            None, self.title, self.size_mainwindow, self.notebook_layout, self.tab_style
+        )
         self.SetTopWindow(window)
 
         load_plugins(self.plugins_list)

--- a/guikit/scripts.py
+++ b/guikit/scripts.py
@@ -6,7 +6,7 @@ import inspect
 from abc import ABC, abstractmethod
 from pathlib import Path
 from shutil import copytree
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from . import APP_NAME
 from . import config as dconfig
@@ -37,11 +37,15 @@ def run():
         else dconfig.NOTEBOOK_LAYOUT
     )
     tab_style = config.TAB_STYLE if "TAB_STYLE" in dir(config) else dconfig.TAB_STYLE
+    size_mainwindow: Tuple[int, int] = (
+        config.SIZE_MAINWINDOW if "SIZE_MAINWINDOW" in dir(config) else (800, 600)
+    )
 
     all_plugins = plug + [p for p in autoplugins if p not in plug]
 
     app = MainApp(
         title=title,
+        size_mainwindow=size_mainwindow,
         plugins_list=all_plugins,
         notebook_layout=nb_layout,
         tab_style=tab_style,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def main_window():
     from guikit.core import MainWindow
 
     app = wx.App()
-    frame = MainWindow(None, "My App")
+    frame = MainWindow(None, title="My App", size=(0, 0))
     yield frame
     wx.CallAfter(frame.Close)
     app.MainLoop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def plugin():
                     bitmap=wx.ArtProvider.GetBitmap(
                         wx.ART_QUIT, wx.ART_TOOLBAR, wx.Size(50, 50)
                     ),
-                ),
+                )
             ]
 
     return ExamplePlugin

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,9 @@ class TestMainApp:
         with patch("guikit.core.MainWindow.Show", MagicMock()):
             from guikit.core import MainApp, MainWindow
 
-            app = MainApp(title="Some App", size_mainwindow=(0, 0), tab_style="a corner")
+            app = MainApp(
+                title="Some App", size_mainwindow=(0, 0), tab_style="a corner"
+            )
             assert "Invalid tab_style" in caplog.messages[-1]
             assert app.tab_style == wx.NB_TOP
             assert isinstance(app.GetTopWindow(), MainWindow)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,7 @@ class TestMainApp:
         with patch("guikit.core.MainWindow.Show", MagicMock()):
             from guikit.core import MainApp, MainWindow
 
-            app = MainApp(title="Some App", tab_style="a corner")
+            app = MainApp(title="Some App", size_mainwindow=(0, 0), tab_style="a corner")
             assert "Invalid tab_style" in caplog.messages[-1]
             assert app.tab_style == wx.NB_TOP
             assert isinstance(app.GetTopWindow(), MainWindow)


### PR DESCRIPTION
* Please check that the main window size value specification in `config.py` is reflected in the view.
* Also make sure that the app still opens (using the default value) if the main size window is not provided in `config.py`

