### PR TITLE
Init threadpool

### DIFF
--- a/guikit/core.py
+++ b/guikit/core.py
@@ -16,6 +16,7 @@ import wx
 
 from .logging import logger
 from .plugins import KNOWN_PLUGINS, MenuTool, PluginBase, load_plugins
+from .threads import ThreadPool
 
 
 class StatusBar(wx.StatusBar):
@@ -236,6 +237,7 @@ class MainApp(wx.App):
             None, self.title, self.size_mainwindow, self.notebook_layout, self.tab_style
         )
         self.SetTopWindow(window)
+        ThreadPool(window)
 
         load_plugins(self.plugins_list)
         window.populate_window()

--- a/guikit/threads.py
+++ b/guikit/threads.py
@@ -208,7 +208,7 @@ class ThreadPool:
         wx.PostEvent(self._window, event)
 
 
-def run_in_thread(
+def run_thread(
     target: Callable,
     on_abort: Optional[Callable] = None,
     on_complete: Optional[Callable] = None,

--- a/guikit/threads.py
+++ b/guikit/threads.py
@@ -51,7 +51,7 @@ class WorkerThread(threading.Thread):
         super(WorkerThread, self).__init__(target=target, daemon=daemon)
         self._on_abort = on_abort
         self._on_complete = on_complete
-        self._on_error = on_error
+        self._on_error = on_error if on_error is not None else logger.error
         self._event_on_abort = wx.NewEventType()
         self._event_on_complete = wx.NewEventType()
         self._event_on_error = wx.NewEventType()

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -144,12 +144,12 @@ class TestThreadPool:
 
 def test_run_in_thread():
     with patch("guikit.threads.ThreadPool", MagicMock()):
-        from guikit.threads import ThreadPool, run_in_thread
+        from guikit.threads import ThreadPool, run_thread
 
         def target():
             pass
 
-        run_in_thread(target)
+        run_thread(target)
         assert ThreadPool().run_thread.call_count == 1
         ThreadPool().run_thread.assert_called_once_with(target, None, None, None, None)
 


### PR DESCRIPTION
- Initialises ThreadPool when the application is launched.
- Adds a default `on_error` callback on theads, logging the error. 

Close #46 