### PR TITLE
Revision of the status bar initialization

### DIFF
--- a/guikit/core.py
+++ b/guikit/core.py
@@ -16,6 +16,7 @@ import wx
 
 from .logging import logger
 from .plugins import KNOWN_PLUGINS, MenuTool, PluginBase, load_plugins
+from .threads import ThreadPool
 
 
 class StatusBar(wx.StatusBar):
@@ -236,6 +237,7 @@ class MainApp(wx.App):
             None, self.title, self.size_mainwindow, self.notebook_layout, self.tab_style
         )
         self.SetTopWindow(window)
+        ThreadPool(window)
 
         load_plugins(self.plugins_list)
         window.populate_window()

--- a/guikit/core.py
+++ b/guikit/core.py
@@ -21,26 +21,22 @@ from .threads import ThreadPool
 
 class StatusBar(wx.StatusBar):
     """
-    Singleton class to manage the top level status and progress bar.
+    Class to manage the top level status and progress bar.
+
+    This class should not be used directly, but rather the `status_bar` instance within
+    the `guikit.core` module shall be used.
 
     It provides two fields:
         - field 0: Automatic display of menu and tools descriptions as well as custom
             status messages
         - field 1: Holds the progress bar. Do not use it for displaying text.
 
-    Use 'StatusBar().SomeMethod` to manage the status bar messages and properties. See
+    Use 'status_bar.SomeMethod` to manage the status bar messages and properties. See
     'wx.StatusBar' for more information about the options available.
 
-    Use `StatusBar().progress_bar.SomeMethod` to manage the progress bar properties.
+    Use `status_bar.progress_bar.SomeMethod` to manage the progress bar properties.
     See 'wx.Gauge' for more information about the options available.
     """
-
-    _instance: Optional[StatusBar] = None
-
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = wx.StatusBar.__new__(cls)
-        return cls._instance
 
     def __init__(self, *args, progress_bar_width: int = 150, **kwargs):
         super(StatusBar, self).__init__(*args, **kwargs)
@@ -67,6 +63,10 @@ class StatusBar(wx.StatusBar):
         self.progress_bar.SetSize(self.GetStatusWidth(1), 10)
 
 
+status_bar: Optional[StatusBar] = None
+"""Main status bar of the program"""
+
+
 class MainWindow(wx.Frame):
     def __init__(
         self,
@@ -80,7 +80,10 @@ class MainWindow(wx.Frame):
         self.size = size
         self.notebook_layout = notebook_layout
         self.tab_style = tab_style
-        self.SetStatusBar(StatusBar(self))
+
+        global status_bar
+        status_bar = StatusBar(self)
+        self.SetStatusBar(status_bar)
 
     def populate_window(self):
         """Adds menu items, tools and other widgets in plugins to the main window."""

--- a/guikit/threads.py
+++ b/guikit/threads.py
@@ -208,7 +208,7 @@ class ThreadPool:
         wx.PostEvent(self._window, event)
 
 
-def run_in_thread(
+def run_thread(
     target: Callable,
     on_abort: Optional[Callable] = None,
     on_complete: Optional[Callable] = None,

--- a/guikit/threads.py
+++ b/guikit/threads.py
@@ -51,7 +51,7 @@ class WorkerThread(threading.Thread):
         super(WorkerThread, self).__init__(target=target, daemon=daemon)
         self._on_abort = on_abort
         self._on_complete = on_complete
-        self._on_error = on_error
+        self._on_error = on_error if on_error is not None else logger.error
         self._event_on_abort = wx.NewEventType()
         self._event_on_complete = wx.NewEventType()
         self._event_on_error = wx.NewEventType()

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -144,12 +144,12 @@ class TestThreadPool:
 
 def test_run_in_thread():
     with patch("guikit.threads.ThreadPool", MagicMock()):
-        from guikit.threads import ThreadPool, run_in_thread
+        from guikit.threads import ThreadPool, run_thread
 
         def target():
             pass
 
-        run_in_thread(target)
+        run_thread(target)
         assert ThreadPool().run_thread.call_count == 1
         ThreadPool().run_thread.assert_called_once_with(target, None, None, None, None)
 


### PR DESCRIPTION
Teh status bar, as a singleton class, was causing trouble when used in real life, making the software to crash. This PR transform it into a normal class and creates an instance of it within the Window constructor, setting it as a module-level variable. 

Close #47 