### PR TITLE
Progress dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        os: [windows-latest, ubuntu-latest, macos-10.15]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ pyversions](https://img.shields.io/pypi/pyversions/guikit.svg)](https://pypi.pyt
 [![PyPI
 license](https://img.shields.io/pypi/l/guikit.svg)](https://pypi.python.org/pypi/guikit/)
 [![Website guikit](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](https://imperialcollegelondon.github.io/guikit/)
-[![Windows](https://svgshare.com/i/ZhY.svg)](https://svgshare.com/i/ZhY.svg)
-[![macOS](https://svgshare.com/i/ZjP.svg)](https://svgshare.com/i/ZjP.svg)
-[![Linux](https://svgshare.com/i/Zhy.svg)](https://svgshare.com/i/Zhy.svg)
 
 # GUIKIT <!-- omit in toc -->
 

--- a/guikit/progress.py
+++ b/guikit/progress.py
@@ -136,7 +136,7 @@ class Dialog(wx.ProgressDialog):
                 f"Current step larger than the maximum: {value}>{self.Range}"
             )
 
-        if not self.IsShown():
+        if not self.IsShownOnScreen():
             self.Show()
 
         if (value % self.every) != 0:

--- a/guikit/progress.py
+++ b/guikit/progress.py
@@ -1,0 +1,133 @@
+from typing import Optional, Tuple
+
+import wx
+from pubsub import pub
+
+
+class Dialog(wx.ProgressDialog):
+    """Opens a modal progress dialog.
+
+    This pogress dialog is pretty much identical to the wx.ProgressDialog it derives
+    except that it predefines the style of the dialog (making it modal, include an abort
+    button, the elapsed and remaining time), and enables updating the progress - as well
+    as informing of the abort condition - via the pubsub messaging system.
+
+    For the pubsub messaging system, the dialog will be:
+
+    - Subscribed to '<channel>.update_progress_dialog', with the same inputs that the
+      progres dialog method 'Update': current step and, optionally, a new value for
+      maximum and a message.
+    - Broadcast the abort condition via '<channel>.abort_process' if the abort button is
+      pressed, with no input arguments.
+
+    If the 'channel' input argument is None, then the pubsub messaging system is not
+    used.
+
+    This dialog also gives a finer control on when it shoould be updated - either the
+    number of times it should be updated over the whole process in total or the number
+    of steps that shoould happen after updating it. This is important because updating
+    the progress dialog adds some overhead to the process, which might be important if
+    it is updated too often.
+
+    Args:
+        - title: Title of the dialog window.
+        - message: Brief messgae describing the process to be carried.
+        - channel: Root channel in which to broadcast/listen for event using the pubsub
+        package.
+        - maximum: The maximum number of steps.
+        - every: The number of steps required to update the dialog.
+        - steps: The total number of times the dialog will be updated in total. If
+        provided, 'every' is overwritten by the calculated new value based on the
+        'maximum' and the 'steps'.
+    """
+
+    def __init__(
+        self,
+        title: str = "",
+        message: str = "",
+        channel: Optional[str] = None,
+        maximum=100,
+        every: int = 1,
+        steps: Optional[int] = None,
+    ):
+        super(Dialog, self).__init__(
+            title,
+            message,
+            style=wx.PD_APP_MODAL
+            | wx.PD_CAN_ABORT
+            | wx.PD_ELAPSED_TIME
+            | wx.PD_REMAINING_TIME,
+            maximum=maximum,
+        )
+        self.channel = channel
+        self.every = every
+        self.steps = steps
+
+        self.SetRange(maximum)
+        self.subscribe_for_updates()
+
+    def SetRange(self, maximum: int) -> None:
+        """Sets a new maximum value for the progress dialog."""
+        super(Dialog, self).SetRange(maximum)
+
+        if self.steps is not None:
+            self.every = maximum // min(maximum, self.steps)
+
+    def Update(
+        self,
+        value: int,
+        msg: str = "",
+        maximum: Optional[int] = None,
+    ) -> Tuple[bool, bool]:
+        """Updates the progress dialog.
+
+        A meesage is broadcast via the <channel>.abort_process if the abort button is
+        clicked and 'channel' was set.
+
+        Args:
+            - current: Current step in the process.
+            - msg: Message to send to the dialog.
+            - maxium: An optional new number of maximum steps.
+
+        Raises:
+            - ValueError if 'value' is not an integer of larger than maximum.
+
+        Returns:
+            A tuple with two bool values indicating if the process has NOT been
+            cancelled and has NOT been skiped. In otherwords, (True, True) indicates
+            that the process should continue normally.
+        """
+        if maximum is not None:
+            self.SetRange(maximum)
+
+        if type(value) != int:
+            raise ValueError("The new 'value' must be an integer")
+        elif value > self.Range:
+            raise ValueError(
+                f"Current step larger than the maximum: {value}>{self.Range}"
+            )
+
+        if (value % self.every) != 0:
+            return (True, True)
+
+        msg = f"{value}/{self.Range}" if msg == "" else f"{msg} - {value}/{self.Range}"
+        continue_progress, skip = super(Dialog, self).Update(value, msg)
+
+        if not continue_progress:
+            self.broadcast_abort()
+
+        return continue_progress, skip
+
+    def subscribe_for_updates(self) -> None:
+        """Subscribe the Update method to the relevant pubsub channel."""
+        if self.channel is None:
+            return
+
+        pub.subscribe(self.Update, f"{self.channel}.update_progress_dialog")
+
+    def broadcast_abort(self) -> None:
+        """Braodcast the message that the process should be aborted."""
+        if self.channel is None:
+            return
+
+        pub.sendMessage(f"{self.channel}.abort_process")

--- a/guikit/progress.py
+++ b/guikit/progress.py
@@ -136,7 +136,7 @@ class Dialog(wx.ProgressDialog):
                 f"Current step larger than the maximum: {value}>{self.Range}"
             )
 
-        if not self.Shown:
+        if not self.IsShown():
             self.Show()
 
         if (value % self.every) != 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ dev =
 	pytest-cov
 	pytest-flake8
 	pytest-mypy
+	pytest-mock
 doc = 
 	sphinx
 	myst-parser

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -62,12 +62,12 @@ class TestDialog:
             # When getting to the last value, hide the dialog
             assert dlg.Update(value=100) is True
             assert dlg.GetValue() == 100
-            assert not dlg.Shown
+            assert not dlg.IsShown()
 
             # If it is hidden and a new value is given, show it again
             assert dlg.Update(value=0) is True
             assert dlg.GetValue() == 0
-            assert dlg.Shown
+            assert dlg.IsShown()
 
     def test_subscribe_for_updates(self, mocker, window):
         from pubsub import pub

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -52,20 +52,20 @@ class TestDialog:
                 dlg.Update(value=maximum + 1)
 
             # If not a multiple of 'every' not update
-            assert dlg.Update(value=1) == (True, False)
+            assert dlg.Update(value=1) is True
             assert dlg.GetValue() == 0
 
             # If a multiple of 'every', update
-            assert dlg.Update(value=2) == (True, False)
+            assert dlg.Update(value=2) is True
             assert dlg.GetValue() == 2
 
             # When getting to the last value, hide the dialog
-            assert dlg.Update(value=100) == (True, False)
+            assert dlg.Update(value=100) is True
             assert dlg.GetValue() == 100
             assert not dlg.Shown
 
             # If it is hidden and a new value is given, show it again
-            assert dlg.Update(value=0) == (True, False)
+            assert dlg.Update(value=0) is True
             assert dlg.GetValue() == 0
             assert dlg.Shown
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -60,15 +60,15 @@ class TestDialog:
             assert dlg.GetValue() == 2
 
             # When getting to the last value, hide the dialog
-            assert dlg.IsShown()
+            assert dlg.IsShownOnScreen()
             assert dlg.Update(value=100)
             assert dlg.GetValue() == 100
-            assert not dlg.IsShown()
+            assert not dlg.IsShownOnScreen()
 
             # If it is hidden and a new value is given, show it again
             assert dlg.Update(value=0)
             assert dlg.GetValue() == 0
-            assert dlg.IsShown()
+            assert dlg.IsShownOnScreen()
 
     def test_subscribe_for_updates(self, mocker, window):
         from pubsub import pub

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 
@@ -60,15 +62,18 @@ class TestDialog:
             assert dlg.GetValue() == 2
 
             # When getting to the last value, hide the dialog
-            assert dlg.IsShownOnScreen()
+            if sys.platform != "win32":
+                assert dlg.IsShownOnScreen()
             assert dlg.Update(value=100)
             assert dlg.GetValue() == 100
-            assert not dlg.IsShownOnScreen()
+            if sys.platform != "win32":
+                assert not dlg.IsShownOnScreen()
 
             # If it is hidden and a new value is given, show it again
             assert dlg.Update(value=0)
             assert dlg.GetValue() == 0
-            assert dlg.IsShownOnScreen()
+            if sys.platform != "win32":
+                assert dlg.IsShownOnScreen()
 
     def test_subscribe_for_updates(self, mocker, window):
         from pubsub import pub

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -60,6 +60,7 @@ class TestDialog:
             assert dlg.GetValue() == 2
 
             # When getting to the last value, hide the dialog
+            assert dlg.IsShown()
             assert dlg.Update(value=100)
             assert dlg.GetValue() == 100
             assert not dlg.IsShown()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,100 @@
+import pytest
+
+
+class TestDialog:
+    def test_constructor(self, mocker, window):
+        from guikit.progress import Dialog
+
+        spy_set_range = mocker.spy(Dialog, "SetRange")
+        spy_subscribe = mocker.spy(Dialog, "subscribe_for_updates")
+
+        with Dialog(maximum=200) as dlg:
+            spy_set_range.assert_called_once_with(dlg, 200)
+            spy_subscribe.assert_called_once()
+
+    def test_set_range(self, window):
+        from guikit.progress import Dialog
+
+        # No using 'steps'
+        with Dialog(maximum=200, every=2) as dlg:
+            assert dlg.Range == 200
+            assert dlg.every == 2
+
+            dlg.SetRange(300)
+            assert dlg.Range == 300
+            assert dlg.every == 2
+
+        # Using steps
+        with Dialog(maximum=200, steps=20) as dlg:
+            assert dlg.Range == 200
+            assert dlg.every == 200 // 20
+
+            dlg.SetRange(300)
+            assert dlg.Range == 300
+            assert dlg.every == 300 // 20
+
+    def test_update(self, mocker, window):
+        from guikit.progress import Dialog
+
+        spy_set_range = mocker.spy(Dialog, "SetRange")
+
+        maximum = 100
+        with Dialog(maximum=maximum, every=2) as dlg:
+
+            # If value is not an integer, raise error
+            with pytest.raises(ValueError):
+                dlg.Update(value=2.2, maximum=100)
+
+            spy_set_range.call_count == 2
+
+            # If the vallue is higher than the maximum, raise error
+            with pytest.raises(ValueError):
+                dlg.Update(value=maximum + 1)
+
+            # If not a multiple of 'every' not update
+            assert dlg.Update(value=1) == (True, False)
+            assert dlg.GetValue() == 0
+
+            # If a multiple of 'every', update
+            assert dlg.Update(value=2) == (True, False)
+            assert dlg.GetValue() == 2
+
+            # When getting to the last value, hide the dialog
+            assert dlg.Update(value=100) == (True, False)
+            assert dlg.GetValue() == 100
+            assert not dlg.Shown
+
+            # If it is hidden and a new value is given, show it again
+            assert dlg.Update(value=0) == (True, False)
+            assert dlg.GetValue() == 0
+            assert dlg.Shown
+
+    def test_subscribe_for_updates(self, mocker, window):
+        from pubsub import pub
+
+        from guikit.progress import Dialog
+
+        spy_subscribe = mocker.spy(pub, "subscribe")
+
+        with Dialog() as dlg:
+            dlg.subscribe_for_updates()
+            spy_subscribe.assert_not_called()
+
+            dlg.channel = "my_channel"
+            dlg.subscribe_for_updates()
+            spy_subscribe.assert_called_once()
+
+    def test_broadcast_abort(self, mocker, window):
+        from pubsub import pub
+
+        from guikit.progress import Dialog
+
+        spy_send = mocker.spy(pub, "sendMessage")
+
+        with Dialog() as dlg:
+            dlg.broadcast_abort()
+            spy_send.assert_not_called()
+
+            dlg.channel = "my_channel"
+            dlg.broadcast_abort()
+            spy_send.assert_called_once()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -52,20 +52,20 @@ class TestDialog:
                 dlg.Update(value=maximum + 1)
 
             # If not a multiple of 'every' not update
-            assert dlg.Update(value=1) is True
+            assert dlg.Update(value=1)
             assert dlg.GetValue() == 0
 
             # If a multiple of 'every', update
-            assert dlg.Update(value=2) is True
+            assert dlg.Update(value=2)
             assert dlg.GetValue() == 2
 
             # When getting to the last value, hide the dialog
-            assert dlg.Update(value=100) is True
+            assert dlg.Update(value=100)
             assert dlg.GetValue() == 100
             assert not dlg.IsShown()
 
             # If it is hidden and a new value is given, show it again
-            assert dlg.Update(value=0) is True
+            assert dlg.Update(value=0)
             assert dlg.GetValue() == 0
             assert dlg.IsShown()
 


### PR DESCRIPTION
Implements a simple to use and flexible modal progress dialog.

This pogress dialog is pretty much identical to the wx.ProgressDialog it derives except that it predefines the style of the dialog (making it modal, include an abort button, the elapsed and remaining time), and enables updating the progress - as well  as informing of the abort condition - via the pubsub messaging system.

For the pubsub messaging system, the dialog will be:

- Subscribed to '<channel>.update_progress_dialog', with the same inputs that the progres dialog method 'Update': current step and, optionally, a new value for maximum and a message.
- Broadcast the abort condition via '<channel>.abort_process' if the abort button is pressed, with no input arguments.

If the 'channel' input argument is None, then the pubsub messaging system is not
used.

This dialog also gives a finer control on when it shoould be updated - either the number of times it should be updated over the whole process in total or the number of steps that should happen after updating it. This is important because updating the progress dialog adds some overhead to the process, which might be important if it is updated too often.

Example of use:

If the loop the dialog is informing about is inmediately accessible, then a direct call to Update can be used. For example:

```python
with Dialog() as dlg:
    for i in range(dlg.Range + 1):
        dlg.Update(i)
        # do something
```

If that is not the case and the loop or recursive function is defined somewhere else, possibly in another module, then the messaging system can be used to communicate with the dialog:

```python
def some_function():
    maximum=300
    pub.sendMessage("my_process.update_progress_dialog", value=0, maximum=maximum)
    for i in range(maximum + 1):
        pub.sendMessage("my_process.update_progress_dialog", value=i)
        # do something

with Dialog(channel="my_process") as dlg:
    some_function()
```
