### PR TITLE
Add tests for new functionality

### DIFF
--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import MagicMock, patch
 
 from pytest import mark, raises
@@ -180,3 +181,16 @@ def test_should_abort():
 
         should_abort()
         ThreadPool().query_abort.called_once_with()
+
+
+def test_stop_threads():
+    with patch("guikit.threads.ThreadPool", MagicMock()):
+        from guikit.threads import ThreadPool
+
+        _COUNT = 3
+        for _ in range(_COUNT):
+            ThreadPool().run_thread(lambda: threading.sleep(0.5))
+
+        assert len(ThreadPool()._workers) == _COUNT
+        ThreadPool().stop_threads()
+        assert not any(worker.is_alive for worker in ThreadPool()._workers)


### PR DESCRIPTION
This is the sort of test I had in mind for the ``stop_threads()`` function.

It currently falls over and dies like so:
```

=================================== FAILURES ====================================
_______________________________ test_stop_threads _______________________________

    def test_stop_threads():
        with patch("guikit.threads.ThreadPool", MagicMock()):
            from guikit.threads import ThreadPool
    
            _COUNT = 3
            for _ in range(_COUNT):
                ThreadPool().run_thread(lambda: threading.sleep(0.5))
    
>           assert len(ThreadPool()._workers) == _COUNT
E           AssertionError: assert 0 == 3
E            +  where 0 = len(<MagicMock name='mock()._workers' id='140196395907680'>)
E            +    where <MagicMock name='mock()._workers' id='140196395907680'> = <MagicMock name='mock()' id='140196396030928'>._workers
E            +      where <MagicMock name='mock()' id='140196396030928'> = <MagicMock id='140196395934304'>()

tests/test_threads.py:194: AssertionError
```